### PR TITLE
fix compiler warning in OTP 20 by removing export_all

### DIFF
--- a/src/cli_tests.erl
+++ b/src/cli_tests.erl
@@ -1,6 +1,8 @@
 -module(cli_tests).
 
--compile([nowarn_unused_function, export_all]).
+-compile([nowarn_unused_function]).
+
+-export([run/0, run/1]).
 
 %% ===================================================================
 %% Run


### PR DESCRIPTION
I received the following error message when trying to build this project:

```
===> Compiling _build/default/lib/cli/src/cli_tests.erl failed
_build/default/lib/cli/src/cli_tests.erl:3: export_all flag enabled - all functions will be exported
```

This PR removes `export_all` from the cli tests file, which now raises a compiler error in OTP 20. Instead, only `run/0` and `run/1` are exported.